### PR TITLE
Azure upload

### DIFF
--- a/etc/motion.conf
+++ b/etc/motion.conf
@@ -411,7 +411,7 @@ on_event_end /usr/bin/node /home/motion/scripts/xively_post.js "stop"
 
 # Command to be executed when a picture (.ppm|.jpg) is saved (default: none)
 # To give the filename as an argument to a command append it with %f
-on_picture_save /usr/bin/node /home/motion/scripts/gdrive_upload.js "%f"
+on_picture_save /bin/sh /home/motion/scripts/motion_upload_wrapper.sh "%f"
 
 # Command to be executed when a motion frame is detected (default: none)
 ; on_motion_detected value

--- a/home/motion/scripts/azure_upload.js
+++ b/home/motion/scripts/azure_upload.js
@@ -1,0 +1,35 @@
+var fs = require("fs");
+
+//Command-line arguments
+var args = process.argv.slice(2);
+
+
+
+
+fs.readFile(args[0], function (err, data) {
+        if (err) throw err;
+
+        var path = require("path");
+        var filename = path.basename(args[0]);
+
+
+        var azure = require('azure-storage');
+
+        var blobSvc = azure.createBlobService(<Your Storage account name>, <Your Access Key>);
+    
+
+        blobSvc.createContainerIfNotExists(<Your Blob Name>, function (error, result, response) {
+            if (!error) {
+                    // Container exists and is private
+                blobSvc.createBlockBlobFromLocalFile(<Your Blob Name>, filename, args[0], function (error, result, response) {
+                    if (!error) {
+                        // file uploaded
+
+                        console.log("Posted file " + filename + "  to Azure Blob ");
+
+                    } else {
+                        console.log(error.type); console.log(error.message);
+                    }
+                });
+            }
+        });

--- a/home/motion/scripts/motion_upload_wrapper.sh
+++ b/home/motion/scripts/motion_upload_wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+/usr/bin/node /home/motion/scripts/azure_upload.js "$1" &
+/usr/bin/node /home/motion/scripts/gdrive_upload.js "$1" &


### PR DESCRIPTION
Changes and additions to script to enable Azure image uploads as well as the original ones. 

To make it work, you need to run the command  _npm install azure-storage_ on the Edison to install the corresponding Azure Storage libraries as well. 